### PR TITLE
let `phone` field be optional. 

### DIFF
--- a/src/api/mainorder_api.py
+++ b/src/api/mainorder_api.py
@@ -63,7 +63,10 @@ def get_main_orders(skip, limit):
 def add_new_main_order(json_body):
     """
     传入一个post的body部分（已转换为json），生成一个新的订单，并在数据库中增加新的一行。
-
+    注意到
+        1. json_body 没有createuser字段，该字段从session中获得
+        2. json_body phone字段为可选项，该字段从user profile中获得，若给了phone字段则从json_body中获取。
+    
     Parameters:
         json_body : json对象 or dict
             包含订单所需的信息
@@ -86,7 +89,10 @@ def add_new_main_order(json_body):
     totalprice = quantity*price
     # createuser = json_body['createuser']
     comments = json_body['comments']
-    phone = json_body['phone']
+    if (json_body.get('phone')):
+        phone = json_body['phone']
+    else:
+        phone = query_result.phone
     status = 1
     progress = 0
     this_order = Orders(

--- a/tests/api/test_mainorder_api.py
+++ b/tests/api/test_mainorder_api.py
@@ -92,7 +92,8 @@ def test_get_main_orders(skip, limit, db_orders, res, monkeypatch):
     @brief Test for add_new_main_order(json_body)
 """
 # TODO: add more tests, including erroneous inputs
-param_add_new_main_order = [(
+param_add_new_main_order = [
+    (
         {
             "name": "None",
             "summary": "None",
@@ -100,9 +101,8 @@ param_add_new_main_order = [(
             "address": "None",
             "quantity": "1",
             "price": "1",
-            "createuser": "1",
             "comments": "None",
-            "phone": "None"
+            "phone": "13538383838"
         },
         {
             "role" : "customer",
@@ -112,7 +112,26 @@ param_add_new_main_order = [(
             "ID" : 1,
         },
         {"code": 0, "msg": "提交成功", "id": 0}
-    )
+    ),
+    (
+        {
+            "name": "None",
+            "summary": "None",
+            "deadline": datetime.datetime.utcnow(),
+            "address": "None",
+            "quantity": "1",
+            "price": "1",
+            "comments": "None",
+        },
+        {
+            "role" : "customer",
+            "username" : "None"
+        },
+        {
+            "ID" : 1,
+        },
+        {"code": 0, "msg": "提交成功", "id": 0}
+    ),
 ]
 
 
@@ -129,7 +148,7 @@ def test_add_new_main_order(json_body,session, targets_user, res, monkeypatch):
                 user = Users(username=username,
                              password="123456",
                              email="spam@spam.com",
-                             phone="None",
+                             phone="13588888888",
                              usertype=0,
                              userstatus=0)
                 user.ID = targets_user["ID"]


### PR DESCRIPTION
fix #17 

Now `phone` field in /apis/order/mainOrder (post) is optional.
By default the backend will get this field from user profile without this field, but you also can explicitly set this field in json body.